### PR TITLE
user 

### DIFF
--- a/app/client/front-end.js
+++ b/app/client/front-end.js
@@ -10,3 +10,14 @@ $(".deleteProdBtn").on('click', (event) => {
     }
   });
 });
+
+$(".deletePayOpBtn").on('click', (event) => {
+  let payOpId = event.target.dataset.id;
+  $.ajax({
+    url: `/payment/${payOpId}`,
+    type: 'DELETE',
+    success: result => {
+        $(`.payment-option[data-id=${payOpId}]`).remove();
+    }
+  });
+});

--- a/app/controllers/managePaymentsCtrl.js
+++ b/app/controllers/managePaymentsCtrl.js
@@ -1,8 +1,17 @@
 'use strict';
 
 module.exports.displayPaymentOptions = (req, res, next) => {
-  // Gets authed user's payment options
-  // Renders manage-payments.pug
+  const { PaymentOption } = req.app.get('models');
+  PaymentOption.findAll({
+    where: {
+      customer_id: req.user.id,
+      deleted: false
+    }
+  })
+    .then(paymentOptions => {
+      console.log(paymentOptions);
+      res.render('manage-payments', { paymentOptions });
+    });
 };
 
 module.exports.displayAddNewPaymentOption = (req, res, next) => {

--- a/app/controllers/managePaymentsCtrl.js
+++ b/app/controllers/managePaymentsCtrl.js
@@ -24,7 +24,20 @@ module.exports.addNewPaymentOption = (req, res, next) => {
 };
 
 module.exports.removePaymentOption = (req, res, next) => {
-  // Deletes payment option from user's account
-  // Re-renders manage-payments.pug?
-  // Or does a client.js fn remove that payment option from the DOM?
+  const { PaymentOption } = req.app.get('models');
+  PaymentOption.find({
+    where: {
+      id: req.params.id,
+      customer_id: req.user.id
+    }
+  })
+    .then(paymentToUpdate => {
+      return paymentToUpdate.updateAttributes({ deleted: true })
+    })
+    .then(updatedPayment => {
+      res.json(updatedPayment);
+    })
+    .catch(err => {
+      next(err);
+    });
 };

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -5,7 +5,7 @@ const router = Router();
 const { getProductsByType, displayAllCategories } = require('../controllers/productTypesCtrl');
 const { searchProductsByName } = require('../controllers/searchCtrl');
 const { displayCart } = require('../controllers/cartCtrl');
-const { displayPaymentOptions } = require('../controllers/managePaymentsCtrl');
+const { displayPaymentOptions, removePaymentOption } = require('../controllers/managePaymentsCtrl');
 const checkAuth = require('./checkAuth');
 
 router.use((req, res, next) => {
@@ -28,6 +28,7 @@ router.use(checkAuth);
 
 router.get('/cart', displayCart);
 router.get('/payment/manage', displayPaymentOptions);
+router.delete('/payment/:id', removePaymentOption);
 
 // require in all the products routes
 router.use('/products', require('./productsRouter'));

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -5,6 +5,7 @@ const router = Router();
 const { getProductsByType, displayAllCategories } = require('../controllers/productTypesCtrl');
 const { searchProductsByName } = require('../controllers/searchCtrl');
 const { displayCart } = require('../controllers/cartCtrl');
+const { displayPaymentOptions } = require('../controllers/managePaymentsCtrl');
 const checkAuth = require('./checkAuth');
 
 router.use((req, res, next) => {
@@ -23,7 +24,10 @@ router.post('/search', searchProductsByName);
 // pipe all other requests through the route modules
 router.use(require('./authRoute'));
 
+router.use(checkAuth);
+
 router.get('/cart', displayCart);
+router.get('/payment/manage', displayPaymentOptions);
 
 // require in all the products routes
 router.use('/products', require('./productsRouter'));

--- a/app/views/manage-payments.pug
+++ b/app/views/manage-payments.pug
@@ -1,6 +1,9 @@
 extends layout
 
 block content
-  //- Displays user's payment options
-  //- Buttons for deleting payment options
-  //- Button for adding a new payment option
+  for payment in paymentOptions
+    .payment-option
+      h3= payment.type
+      p= 'Account Number: '
+        for digit in payment.account_number.toString()
+          ='•'

--- a/app/views/manage-payments.pug
+++ b/app/views/manage-payments.pug
@@ -2,8 +2,9 @@ extends layout
 
 block content
   for payment in paymentOptions
-    .payment-option
+    .payment-option(data-id=payment.id)
       h3= payment.type
       p= 'Account Number: '
         for digit in payment.account_number.toString()
           ='•'
+        button.deletePayOpBtn(data-id=payment.id) delete

--- a/app/views/partials/nav.pug
+++ b/app/views/partials/nav.pug
@@ -12,6 +12,7 @@ nav.navbar.navbar-expand-lg.navbar-light.bg-light
         .dropdown-menu
           a.dropdown-item(href='/settings') my account
           a.dropdown-item(href='/products/manage') manage products
+          a.dropdown-item(href='/payment/manage') manage payment types
         li.nav-item
           a.nav-link(href='/cart') view cart
         li.nav-item


### PR DESCRIPTION
# Description
User can view all their undeleted payment types and delete any of them.

## Related Ticket(s)
fixes #22, fixes #26, fixes #44

## Steps to Test Solution
1. `npm run db:gen`
1. `npm start`
1. Log in as Bonita84@yahoo.com (username and pass are `Bonita84@yahoo.com`)
1. Click the email dropdown and click "manage payment types"
1. You should see 2 payment types, Visa and Piece of paper
1. Delete them. They should go away and if you want to check the database, PaymentOptions 2 and 28 should now say `deleted` is `true`