### PR TITLE
Customer's settings view

### DIFF
--- a/app/controllers/managePaymentsCtrl.js
+++ b/app/controllers/managePaymentsCtrl.js
@@ -9,7 +9,6 @@ module.exports.displayPaymentOptions = (req, res, next) => {
     }
   })
     .then(paymentOptions => {
-      console.log(paymentOptions);
       res.render('manage-payments', { paymentOptions });
     });
 };

--- a/app/controllers/settingsCtrl.js
+++ b/app/controllers/settingsCtrl.js
@@ -1,6 +1,11 @@
 'use strict';
 
 module.exports.displayUsersSettings = (req, res, next) => {
-  //Gets all of a user's settings
-  //Renders settings.pug
+  const { Customer, PaymentOption } = req.app.get('models');
+
+  Customer.findById(req.user.id)
+  .then(({dataValues}) => {
+    res.render('settings', dataValues);
+  })
+  .catch(err => res.status(404));
 };

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -22,9 +22,10 @@ router.use((req, res, next) => {
 router.get('/', displayAllCategories);
 router.get('/categories/:id', getProductsByType);
 router.post('/search', searchProductsByName);
+router.use('/products', require('./productsRouter'));
 
-// pipe all other requests through the route modules
 router.use(require('./authRoute'));
+
 
 router.use(checkAuth);
 
@@ -32,10 +33,7 @@ router.get('/cart', displayCart);
 router.get('/payment/manage', displayPaymentOptions);
 router.delete('/payment/:id', removePaymentOption);
 
-router.get('/settings', checkAuth, displayUsersSettings);
-
-// require in all the products routes
-router.use('/products', require('./productsRouter'));
+router.get('/settings', displayUsersSettings);
 
 // Default route
 router.use((req, res, next) => {

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -6,13 +6,15 @@ const { getProductsByType, displayAllCategories } = require('../controllers/prod
 const { searchProductsByName } = require('../controllers/searchCtrl');
 const { displayCart } = require('../controllers/cartCtrl');
 const { displayPaymentOptions, removePaymentOption } = require('../controllers/managePaymentsCtrl');
+const { displayUsersSettings } = require('../controllers/settingsCtrl');
+
 const checkAuth = require('./checkAuth');
 
 router.use((req, res, next) => {
   const { ProductType } = req.app.get('models');
   ProductType.findAll()
     .then(prodTypes => {
-      res.locals.categories = prodTypes; 
+      res.locals.categories = prodTypes;
       next();
     });
 });
@@ -29,6 +31,8 @@ router.use(checkAuth);
 router.get('/cart', displayCart);
 router.get('/payment/manage', displayPaymentOptions);
 router.delete('/payment/:id', removePaymentOption);
+
+router.get('/settings', checkAuth, displayUsersSettings);
 
 // require in all the products routes
 router.use('/products', require('./productsRouter'));

--- a/app/views/settings.pug
+++ b/app/views/settings.pug
@@ -16,5 +16,6 @@ block content
           b=phone_number
         p Email: 
           b=email
-    form(action='/payment/manage' method='get')
-      button.btn.btn-primary(type='submit') Manage Payment Options
+    .row
+      form(action='/payment/manage' method='get').mx-auto.mt-5
+        button.btn.btn-primary(type='submit') Manage Payment Options

--- a/app/views/settings.pug
+++ b/app/views/settings.pug
@@ -17,5 +17,4 @@ block content
         p Email: 
           b=email
     .row
-      form(action='/payment/manage' method='get').mx-auto.mt-5
-        button.btn.btn-primary(type='submit') Manage Payment Options
+      a.btn.btn-primary(href='/payment/manage') Manage Payment Options

--- a/app/views/settings.pug
+++ b/app/views/settings.pug
@@ -1,5 +1,20 @@
 extends layout
 
 block content
-  //- Displays a user's settings
-  //- Button for managing payment options
+  h1.text-center Settings
+  .container-fluid
+    h3 #{first_name} #{last_name}
+    .row
+      .col-6.card 
+        .card-title.text-center Address
+        p=street_address
+        p #{city}, #{state}
+        p=postal_code
+      .col-6.card
+        .card-title.text-center Contact
+        p Phone: 
+          b=phone_number
+        p Email: 
+          b=email
+    form(action='/payment/manage' method='get')
+      button.btn.btn-primary(type='submit') Manage Payment Options


### PR DESCRIPTION
# Description
`/settings` now displays the authenticated user's settings

## Related Ticket(s)
Fixes #64, fixes #66

## Problem to Solve
User had no way to view their settings, bummer!

## Expected Behavior
When the user is authenticated, clicking on their email in navbar & then 'my settings' brings them to a view with their settings.
Clicking on 'Manage Payment Options' takes them to `/payment/manage`

## Steps to Test Solution

1. `npm start`
1. Login in with `Shakira86@gmail.com`
1. Click on their email, and then `my account`
1. Pretty!
1. Click on `Manage Payment Options`
1. Look at Kenzie's cool code!

