### PR TITLE
Refactored prodTypes controller

### DIFF
--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -2,7 +2,7 @@
 
 const { Router } = require('express');
 const router = Router();
-const { getProductsByType, displayAllCategories } = require('../controllers/productTypesCtrl');
+const { displayCategory, displayAllCategories } = require('../controllers/productTypesCtrl');
 const { searchProductsByName } = require('../controllers/searchCtrl');
 const { displayCart } = require('../controllers/cartCtrl');
 const { displayPaymentOptions, removePaymentOption } = require('../controllers/managePaymentsCtrl');
@@ -20,7 +20,7 @@ router.use((req, res, next) => {
 });
 
 router.get('/', displayAllCategories);
-router.get('/categories/:id', getProductsByType);
+router.get('/categories/:id', displayCategory);
 router.post('/search', searchProductsByName);
 router.use('/products', require('./productsRouter'));
 

--- a/app/views/partials/allProductTypes.pug
+++ b/app/views/partials/allProductTypes.pug
@@ -1,4 +1,6 @@
-for cat in prodType
-  h3 #{cat.type}(#{cat.array_agg.length})
-  for product in cat.array_agg.slice(0,3)
-      p=product
+for cat in prodTypes
+  h3
+    a(href='/categories/'+cat.id) #{cat.title} (#{cat.products.length})
+  for product in cat.products.slice(0,3)
+      p
+        a(href='/products/details/'+product.id)= product.title


### PR DESCRIPTION
# Description
- Categories and products on homepage should now be linked.
- Refactored product type controller to reuse sequelize selections

## Related Ticket(s)
fixes #37, fixes #62 

## Steps to Test Solution
1. `npm run db:gen`
1. `npm start`
1. Go to the homepage (`/`); the categories and products should be linked.
1. The quantities on the homepage should match up with the number of products that show up when you click on that category.