### PR TITLE
Adding Payment Types

### DIFF
--- a/app/controllers/managePaymentsCtrl.js
+++ b/app/controllers/managePaymentsCtrl.js
@@ -29,7 +29,7 @@ module.exports.addNewPaymentOption = (req, res, next) => {
   })
   .then( addedPayment => {
     //TODO REDIRECT TO MANAGE PAYMENT
-    res.redirect('/welcome');
+    res.redirect('/payment/manage');
   })
   // Re-directs to manage-payments.pug
 };

--- a/app/controllers/managePaymentsCtrl.js
+++ b/app/controllers/managePaymentsCtrl.js
@@ -13,13 +13,13 @@ module.exports.displayPaymentOptions = (req, res, next) => {
     });
 };
 
+//renders form for adding new payment type
 module.exports.displayAddNewPaymentOption = (req, res, next) => {
   res.render('new-payment-option');
 };
 
+// Posts new payment option for current user
 module.exports.addNewPaymentOption = (req, res, next) => {
-  // Posts validated form from new-payment-option.pug
-  console.log("RECEIVED FROM FORM", req.body);
   const { PaymentOption } = req.app.get('models');
   PaymentOption.create({
     type: req.body.type,
@@ -28,10 +28,8 @@ module.exports.addNewPaymentOption = (req, res, next) => {
     deleted: false
   })
   .then( addedPayment => {
-    //TODO REDIRECT TO MANAGE PAYMENT
     res.redirect('/payment/manage');
   })
-  // Re-directs to manage-payments.pug
 };
 
 module.exports.removePaymentOption = (req, res, next) => {

--- a/app/controllers/managePaymentsCtrl.js
+++ b/app/controllers/managePaymentsCtrl.js
@@ -11,7 +11,17 @@ module.exports.displayAddNewPaymentOption = (req, res, next) => {
 
 module.exports.addNewPaymentOption = (req, res, next) => {
   // Posts validated form from new-payment-option.pug
-  {  }
+  console.log("RECEIVED FROM FORM", req.body);
+  const { PaymentOption } = req.app.get('models');
+  PaymentOption.create({
+    type: req.body.type,
+    account_number: req.body.account_number,
+    customer_id: req.user.id,
+    deleted: false
+  })
+  .then( addedPayment => {
+    console.log(addedPayment);
+  })
   // Re-directs to manage-payments.pug
 };
 

--- a/app/controllers/managePaymentsCtrl.js
+++ b/app/controllers/managePaymentsCtrl.js
@@ -6,11 +6,12 @@ module.exports.displayPaymentOptions = (req, res, next) => {
 };
 
 module.exports.displayAddNewPaymentOption = (req, res, next) => {
-  // Renders new-payment-option.pug
+  res.render('new-payment-option');
 };
 
 module.exports.addNewPaymentOption = (req, res, next) => {
   // Posts validated form from new-payment-option.pug
+  {  }
   // Re-directs to manage-payments.pug
 };
 

--- a/app/controllers/managePaymentsCtrl.js
+++ b/app/controllers/managePaymentsCtrl.js
@@ -20,7 +20,8 @@ module.exports.addNewPaymentOption = (req, res, next) => {
     deleted: false
   })
   .then( addedPayment => {
-    console.log(addedPayment);
+    //TODO REDIRECT TO MANAGE PAYMENT
+    res.redirect('/welcome');
   })
   // Re-directs to manage-payments.pug
 };

--- a/app/models/index.js
+++ b/app/models/index.js
@@ -5,9 +5,9 @@ var path      = require('path');
 var Sequelize = require('sequelize');
 var basename  = path.basename(module.filename);
 var env       = process.env.NODE_ENV || 'development';
-var config    = require(__dirname + '/config/config.json')[env];
+// var config    = require(__dirname + '/config/config.json')[env];
 // **NOTE: If running windows, use the below path for running this app instead of the above.
-// var config    = require(__dirname + '\\config\\config.json')[env];
+var config    = require(__dirname + '\\config\\config.json')[env];
 var db        = {};
 
 if (config.use_env_variable) {

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -31,7 +31,7 @@ router.use('/products', require('./productsRouter'));
 //TODO: Sync with Kenzie on product route module
 const { displayAddNewPaymentOption, addNewPaymentOption } = require('../controllers/managePaymentsCtrl');
 router.get('/payments/new', displayAddNewPaymentOption);
-router.put('/payments/new', addNewPaymentOption);
+router.post('/payments/new', addNewPaymentOption);
 
 // Default route
 router.use((req, res, next) => {

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -5,7 +5,6 @@ const router = Router();
 const { getProductsByType, displayAllCategories } = require('../controllers/productTypesCtrl');
 const { searchProductsByName } = require('../controllers/searchCtrl');
 const { displayCart } = require('../controllers/cartCtrl');
-const { displayPaymentOptions, removePaymentOption } = require('../controllers/managePaymentsCtrl');
 const { displayUsersSettings } = require('../controllers/settingsCtrl');
 
 const checkAuth = require('./checkAuth');
@@ -30,13 +29,11 @@ router.use(require('./authRoute'));
 router.use(checkAuth);
 
 router.get('/cart', displayCart);
-router.get('/payment/manage', displayPaymentOptions);
-router.delete('/payment/:id', removePaymentOption);
 
 router.get('/settings', displayUsersSettings);
 
 // require in all the payments routes
-router.use('/payments', require('./paymentsRouter'));
+router.use('/payment', require('./paymentsRouter'));
 
 
 // Default route

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -28,10 +28,9 @@ router.get('/cart', displayCart);
 // require in all the products routes
 router.use('/products', require('./productsRouter'));
 
-//TODO: Sync with Kenzie on product route module
-const { displayAddNewPaymentOption, addNewPaymentOption } = require('../controllers/managePaymentsCtrl');
-router.get('/payments/new', displayAddNewPaymentOption);
-router.post('/payments/new', addNewPaymentOption);
+// require in all the payments routes
+router.use('/payments', require('./paymentsRouter'));
+
 
 // Default route
 router.use((req, res, next) => {

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -28,6 +28,11 @@ router.get('/cart', displayCart);
 // require in all the products routes
 router.use('/products', require('./productsRouter'));
 
+//TODO: Sync with Kenzie on product route module
+const { displayAddNewPaymentOption, addNewPaymentOption } = require('../controllers/managePaymentsCtrl');
+router.get('/payments/new', displayAddNewPaymentOption);
+router.put('/payments/new', addNewPaymentOption);
+
 // Default route
 router.use((req, res, next) => {
   res.redirect('/');

--- a/app/routes/paymentsRouter.js
+++ b/app/routes/paymentsRouter.js
@@ -8,10 +8,16 @@ const { displayPaymentOptions, removePaymentOption, displayAddNewPaymentOption, 
 //all routes below this line will require authentication
 paymentsRouter.use(checkAuth);
 
+//route which displays all users payment option
 paymentsRouter.get('/manage', displayPaymentOptions);
+
+//when user clicks delete on payment type
 paymentsRouter.delete('/:id', removePaymentOption);
 
+//when user clicks Add Payment Option
 paymentsRouter.get('/new', displayAddNewPaymentOption);
+
+//when user has filled out form to add new payment option and clicked add
 paymentsRouter.post('/new', addNewPaymentOption);
 
 module.exports = paymentsRouter;

--- a/app/routes/paymentsRouter.js
+++ b/app/routes/paymentsRouter.js
@@ -3,10 +3,13 @@
 const { Router } = require('express');
 const paymentsRouter = Router();
 const checkAuth = require('./checkAuth');
-const { displayAddNewPaymentOption, addNewPaymentOption } = require('../controllers/managePaymentsCtrl');
+const { displayPaymentOptions, removePaymentOption, displayAddNewPaymentOption, addNewPaymentOption } = require('../controllers/managePaymentsCtrl');
 
 //all routes below this line will require authentication
 paymentsRouter.use(checkAuth);
+
+paymentsRouter.get('/manage', displayPaymentOptions);
+paymentsRouter.delete('/:id', removePaymentOption);
 
 paymentsRouter.get('/new', displayAddNewPaymentOption);
 paymentsRouter.post('/new', addNewPaymentOption);

--- a/app/routes/paymentsRouter.js
+++ b/app/routes/paymentsRouter.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const { Router } = require('express');
+const paymentsRouter = Router();
+const checkAuth = require('./checkAuth');
+const { displayAddNewPaymentOption, addNewPaymentOption } = require('../controllers/managePaymentsCtrl');
+
+//all routes below this line will require authentication
+paymentsRouter.use(checkAuth);
+
+paymentsRouter.get('/new', displayAddNewPaymentOption);
+paymentsRouter.post('/new', addNewPaymentOption);
+
+module.exports = paymentsRouter;

--- a/app/views/manage-payments.pug
+++ b/app/views/manage-payments.pug
@@ -8,3 +8,4 @@ block content
         for digit in payment.account_number.toString()
           ='•'
         button.deletePayOpBtn(data-id=payment.id) delete
+  a.btn.btn-primary(href='/payment/new') Add Payment Option

--- a/app/views/new-payment-option.pug
+++ b/app/views/new-payment-option.pug
@@ -2,7 +2,7 @@ extends layout
 
 block content
   h1 Add New Payment Option
-  form(action="/payments/new" method="post")
+  form(action="/payment/new" method="post")
     input(type="text" name="type" placeholder="Payment Type")
     input(type="number" name="account_number" placeholder="Account Number")
     button(type="submit" text="Submit") Add

--- a/app/views/new-payment-option.pug
+++ b/app/views/new-payment-option.pug
@@ -1,4 +1,8 @@
 extends layout
 
 block content
-  //- Form for adding a new payment option to a user's account
+  h1 Add New Payment Option
+  form(action="payments/new" method="post")
+    input(type="text" name="type" placeholder="Payment Type")
+    input(type="number" name="account_number" placeholder="Account Number")
+    button(type="submit" text="Submit") Add

--- a/app/views/new-payment-option.pug
+++ b/app/views/new-payment-option.pug
@@ -2,7 +2,7 @@ extends layout
 
 block content
   h1 Add New Payment Option
-  form(action="payments/new" method="post")
+  form(action="/payments/new" method="post")
     input(type="text" name="type" placeholder="Payment Type")
     input(type="number" name="account_number" placeholder="Account Number")
     button(type="submit" text="Submit") Add

--- a/app/views/new-payment-option.pug
+++ b/app/views/new-payment-option.pug
@@ -3,6 +3,6 @@ extends layout
 block content
   h1 Add New Payment Option
   form(action="/payment/new" method="post")
-    input(type="text" name="type" placeholder="Payment Type")
-    input(type="number" name="account_number" placeholder="Account Number")
+    input(type="text" name="type" placeholder="Payment Type" required="true")
+    input(type="number" name="account_number" placeholder="Account Number" required="true")
     button(type="submit" text="Submit") Add

--- a/app/views/partials/nav.pug
+++ b/app/views/partials/nav.pug
@@ -12,8 +12,6 @@ nav.navbar.navbar-expand-lg.navbar-light.bg-light
         .dropdown-menu
           a.dropdown-item(href='/settings') my account
           a.dropdown-item(href='/products/manage') manage products
-          //TODO: DELETE BELOW PATH
-          a.dropdown-item(href='/payments/new') add payment
           a.dropdown-item(href='/payment/manage') manage payment types
         li.nav-item
           a.nav-link(href='/cart') view cart

--- a/app/views/partials/nav.pug
+++ b/app/views/partials/nav.pug
@@ -12,6 +12,8 @@ nav.navbar.navbar-expand-lg.navbar-light.bg-light
         .dropdown-menu
           a.dropdown-item(href='/settings') my account
           a.dropdown-item(href='/products/manage') manage products
+          //TODO: DELETE BELOW PATH
+          a.dropdown-item(href='/payments/new') add payment
         li.nav-item
           a.nav-link(href='/cart') view cart
         li.nav-item


### PR DESCRIPTION
# Description
This PR covers the ability for a user to add a payment type. It also consolidates the payment routes to one module.

## Related Ticket(s)
Fixes #27
Fixes #22

## Problem to Solve
A user can add a new payment type


## Expected Behavior
When viewing payment types, a user can choose to add a new payment 

## Steps to Test Solution

1. ``` npm start ```
2. log in to any account
3. select My Account --> Manage Payment Types --> Add Payment Option
4. add a payment type! 
5. Your payment type should be saved and displayed to redirect - you can check squelectron or pgadmin to verify

