### PR TITLE
redirect to product details page on completion

### DIFF
--- a/app/controllers/manageProductsCtrl.js
+++ b/app/controllers/manageProductsCtrl.js
@@ -73,8 +73,7 @@ module.exports.addNewProductForSale = (req, res, next) => {
       creator_id: req.user.id
     })
     .then(newRecord => {
-      // this is a temp fix- this will re-route to product details for this product once we have that partial built
-      res.status(201).json(newRecord); 
+      res.redirect(`/products/details/${newRecord.id}`);
     })
     .catch(err => {
       next(err);


### PR DESCRIPTION
# Description
When you add a product, you go to the details page instead of seeing JSON.

## Related Ticket(s)
fixes #60 

## Steps to Test Solution
1. `npm run db:generate`
1. `npm start`
1. Log in as anybody (`Linnea_Batz75@hotmail.com`/`Linnea_Batz75@hotmail.com`)
1. Email dropdown > manage products > add new product
1. Fill out the form with garbage
1. Submit and you should be redirected to the new product's detail page.