### PR TITLE
product types don't show products that are sold out

### DIFF
--- a/app/controllers/productTypesCtrl.js
+++ b/app/controllers/productTypesCtrl.js
@@ -35,6 +35,7 @@ const getProductsByType = id => {
         products.forEach((p, index) => {
           p.quantity_left = qtys[index];
         });
+        products = products.filter(p => p.quantity_left > 0);
         resolve({ products, prodType });
       })
       .catch(err => reject(err));


### PR DESCRIPTION
# Description
Homepage categories and category pages do not show or count sold out products.

## Related Ticket(s)
fixes #77 

## Problem to Solve
A few products were showing up on the homepage with `qty_left` of 0.

## Steps to Test Solution
1. `npm run db:gen`
1. `npm start`
1. Go to homepage. Two of the `Outdoor` cats should have 0 items in it and should show no products when clicked.