### PR TITLE
Fixes #77: account_number is now a string

### DIFF
--- a/app/models/paymentoption.js
+++ b/app/models/paymentoption.js
@@ -3,7 +3,7 @@ module.exports = (sequelize, DataTypes) => {
   var PaymentOption = sequelize.define('PaymentOption', {
     type: DataTypes.STRING,
     deleted: DataTypes.BOOLEAN,
-    account_number: DataTypes.INTEGER,
+    account_number: DataTypes.STRING,
     customer_id: DataTypes.INTEGER
   }, {});
   PaymentOption.associate = function(models) {

--- a/app/views/new-payment-option.pug
+++ b/app/views/new-payment-option.pug
@@ -4,5 +4,5 @@ block content
   h1 Add New Payment Option
   form(action="/payment/new" method="post")
     input(type="text" name="type" placeholder="Payment Type" required="true")
-    input(type="number" name="account_number" placeholder="Account Number" required="true")
+    input(type="text" name="account_number" placeholder="Account Number" required="true")
     button(type="submit" text="Submit") Add


### PR DESCRIPTION
## Related Ticket(s)
Fixes #77 

## Problem to Solve
`account_number` on `PaymentOptions` was an integer, causing problems. Now its a string.
Updates `new-payment-option.pug` `input` for `account_number`

## Steps to Test Solution

1. MUST DO: `npm run db:gen`
1. Not really much to test here...